### PR TITLE
Remove reference to staticarrays.construct_sametype

### DIFF
--- a/src/ssubarray.jl
+++ b/src/ssubarray.jl
@@ -289,10 +289,3 @@ else
 end
 
 axes(S::SSubArray) = (Base.@_inline_meta; _indices_sub(S.indices...))
-
-@inline function StaticArrays._construct_sametype(a::Type{<:SSubArray{S}}, elements) where {S}
-    return SArray{S}(elements)
-end
-@inline function StaticArrays._construct_sametype(a::SSubArray, elements)
-    return StaticArrays._construct_sametype(typeof(a), elements)
-end


### PR DESCRIPTION
No idea what that function does, I have HybridArrays as a dependency, this is breaking compilation right now, and simply removing was fine. Should we perhaps pin down the appropriate version of StaticArrays?... Or is this actually something that can really be removed?