### PR TITLE
add parent and elsize

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -1,13 +1,17 @@
 
-Base.dataids(sa::HybridArray) = Base.dataids(sa.data)
+@inline Base.parent(sa::HybridArray) = sa.data
 
-@inline size(sa::HybridArray{S,T,N,N}) where {S,T,N} = size(sa.data)
+Base.dataids(sa::HybridArray) = Base.dataids(parent(sa))
 
-@inline length(sa::HybridArray) = length(sa.data)
+@inline Base.elsize(sa::HybridArray) = Base.elsize(parent(sa))
 
-@inline strides(sa::HybridArray{S,T,N,N}) where {S,T,N} = strides(sa.data)
+@inline size(sa::HybridArray{S,T,N,N}) where {S,T,N} = size(parent(sa))
 
-@inline pointer(sa::HybridArray) = pointer(sa.data)
+@inline length(sa::HybridArray) = length(parent(sa))
+
+@inline strides(sa::HybridArray{S,T,N,N}) where {S,T,N} = strides(parent(sa))
+
+@inline pointer(sa::HybridArray) = pointer(parent(sa))
 
 @generated function _sized_abstract_array_axes(::Type{S}, ax::Tuple) where S<:Tuple
     exprs = Any[]
@@ -22,7 +26,7 @@ Base.dataids(sa::HybridArray) = Base.dataids(sa.data)
 end
 
 function axes(sa::HybridArray{S}) where S
-    ax = axes(sa.data)
+    ax = axes(parent(sa))
     return _sized_abstract_array_axes(S, ax)
 end
 
@@ -32,9 +36,9 @@ function promote_rule(::Type{<:HybridArray{S,T,N,M,TDataA}}, ::Type{<:HybridArra
     HybridArray{S,TU,N,M,promote_type(TDataA, TDataB)::Type{<:AbstractArray{TU}}}
 end
 
-@inline copy(a::HybridArray) = typeof(a)(copy(a.data))
+@inline copy(a::HybridArray) = typeof(a)(copy(parent(a)))
 
-similar(a::HA, ::Type{T2}) where {S, HA<:HybridArray{S}, T2} = HybridArray{S, T2}(similar(a.data, T2))
+similar(a::HA, ::Type{T2}) where {S, HA<:HybridArray{S}, T2} = HybridArray{S, T2}(similar(parent(a), T2))
 
 similar(::Type{<:HybridArray{S,T,N,M}},::Type{T2}) where {S,T,N,M,T2} = HybridArray{S,T2,N,M}(undef)
 similar(::Type{SA},::Type{T},s::Size{S}) where {SA<:HybridArray,T,S} = hybridarray_similar_type(T,s,StaticArrays.length_val(s))(undef)
@@ -48,9 +52,9 @@ _h_similar_type(::Type{A},::Type{T},s::Size{S}) where {A<:HybridArray,T,S} = hyb
 
 Size(::Type{<:HybridArray{S}}) where {S} = Size(S)
 
-Base.IndexStyle(a::HybridArray) = Base.IndexStyle(a.data)
+Base.IndexStyle(a::HybridArray) = Base.IndexStyle(parent(a))
 Base.IndexStyle(::Type{HA}) where {S,T,N,M,TData,HA<:HybridArray{S,T,N,M,TData}} = Base.IndexStyle(TData)
 
-Base.vec(a::HybridArray) = vec(a.data)
+Base.vec(a::HybridArray) = vec(parent(a))
 
 StaticArrays.similar_type(::Type{<:SSubArray},::Type{T},s::Size{S}) where {S,T} = StaticArrays.default_similar_type(T,s,StaticArrays.length_val(s))

--- a/src/array_interface_compat.jl
+++ b/src/array_interface_compat.jl
@@ -16,7 +16,7 @@ function ArrayInterface.restructure(x::HybridArray{S}, y) where {S}
 end
 
 function ArrayInterface.strides(x::HybridArray)
-    return ArrayInterface.strides(x.data)
+    return ArrayInterface.strides(parent(x))
 end
 
 @generated function ArrayInterface.strides(x::HybridArray{S,T,N,N,Array{T,N}}) where {S,T,N}
@@ -35,7 +35,7 @@ end
         end
     end
     return quote
-        datastrides = strides(x.data)
+        datastrides = strides(parent(x))
         return tuple($(collected_strides...))
     end
 end
@@ -50,7 +50,7 @@ end
         end
     end
     return quote
-        datasize = ArrayInterface.size(x.data)
+        datasize = ArrayInterface.size(parent(x))
         return tuple($(collected_sizes...))
     end
 end

--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -1,5 +1,5 @@
 
-Base.one(A::HA) where {HA<:HybridMatrix} = HA(one(A.data))
+Base.one(A::HA) where {HA<:HybridMatrix} = HA(one(parent(A)))
 
 # This should make one(sized subarray) return SArray
 @inline function StaticArrays._construct_sametype(a::Type{<:SSubArray{Tuple{S,S},T}}, elements) where {S,T}
@@ -9,10 +9,10 @@ end
     return SMatrix{S,S,T}(elements)
 end
 
-Base.fill!(A::HybridArray, x) = fill!(A.data, x)
+Base.fill!(A::HybridArray, x) = fill!(parent(A), x)
 
 @inline function Base.zero(a::HybridArray{S}) where {S}
-    return HybridArray{S}(zero(a.data))
+    return HybridArray{S}(zero(parent(a)))
 end
 
 @inline function Base.zero(a::SSubArray{S,T}) where {S,T}

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -5,18 +5,18 @@ Base.@propagate_inbounds (::Type{HybridArray{S,T,N}})(a::AbstractArray) where {S
 Base.@propagate_inbounds (::Type{HybridArray{S,T}})(a::AbstractArray) where {S,T} = convert(HybridArray{S,T}, a)
 
 # Overide some problematic default behaviour
-@inline convert(::Type{SA}, sa::HybridArray) where {SA<:HybridArray} = SA(sa.data)
+@inline convert(::Type{SA}, sa::HybridArray) where {SA<:HybridArray} = SA(parent(sa))
 @inline convert(::Type{SA}, sa::SA) where {SA<:HybridArray} = sa
 
 # Back to Array (unfortunately need both convert and construct to overide other methods)
-@inline Array(sa::HybridArray{S}) where {S} = Array(sa.data)
-@inline Array{T}(sa::HybridArray{S,T}) where {T,S} = Array{T}(sa.data)
-@inline Array{T,N}(sa::HybridArray{S,T,N}) where {T,S,N} = Array{T,N}(sa.data)
+@inline Array(sa::HybridArray{S}) where {S} = Array(parent(sa))
+@inline Array{T}(sa::HybridArray{S,T}) where {T,S} = Array{T}(parent(sa))
+@inline Array{T,N}(sa::HybridArray{S,T,N}) where {T,S,N} = Array{T,N}(parent(sa))
 
-@inline convert(::Type{Array}, sa::HybridArray) = convert(Array, sa.data)
-@inline convert(::Type{Array{T}}, sa::HybridArray{S,T}) where {T,S} = convert(Array, sa.data)
-@inline convert(::Type{Array{T,N}}, sa::HybridArray{S,T,N}) where {T,S,N} = convert(Array, sa.data)
-@inline convert(::Type{Array{T,N} where T}, sa::HybridArray{S}) where {S,N} = convert(Array, sa.data)
+@inline convert(::Type{Array}, sa::HybridArray) = convert(Array, parent(sa))
+@inline convert(::Type{Array{T}}, sa::HybridArray{S,T}) where {T,S} = convert(Array, parent(sa))
+@inline convert(::Type{Array{T,N}}, sa::HybridArray{S,T,N}) where {T,S,N} = convert(Array, parent(sa))
+@inline convert(::Type{Array{T,N} where T}, sa::HybridArray{S}) where {S,N} = convert(Array, parent(sa))
 
 function check_compatible_sizes(::Type{S}, a::NTuple{N,Int}) where {S,N}
     st = size_to_tuple(S)
@@ -66,4 +66,4 @@ end
     convert(HybridArray{S,T}, a)
 end
 
-@inline Base.unsafe_convert(::Type{Ptr{T}}, A::HybridArray{S,T}) where {S,T} = pointer(A.data)
+@inline Base.unsafe_convert(::Type{Ptr{T}}, A::HybridArray{S,T}) where {S,T} = pointer(parent(A))

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -124,14 +124,14 @@ end
         end
         return quote
             Base.@_propagate_inbounds_meta
-            sadata = sa.data
+            sadata = parent(sa)
             SArray{$Tnewsize,$T}(tuple($(exprs...)))
         end
     else
         exprs = [:(getindex(sadata, $id)) for id ∈ lininds[2]]
         return quote
             Base.@_propagate_inbounds_meta
-            sadata = sa.data
+            sadata = parent(sa)
             $(lininds[1])
             SArray{$Tnewsize,$T}(tuple($(exprs...)))
         end
@@ -214,7 +214,7 @@ end
 
 @inline function _setindex!(::Val{:dynamic_fixed_false}, sa::HybridArray{S}, value, inds::Union{Int, StaticArray{<:Tuple, Int}, Colon}...) where S
     newsize = new_out_size(S, inds...)
-    return HybridArray{newsize}(setindex!(sa.data, value, inds...))
+    return HybridArray{newsize}(setindex!(parent(sa), value, inds...))
 end
 
 Base.@propagate_inbounds function _setindex!(::Val{:dynamic_fixed_true}, sa::HybridArray, value, inds::Union{Int, StaticArray{<:Tuple, Int}, Colon}...)
@@ -248,7 +248,7 @@ end
         if v <: StaticArray
             return quote
                 Base.@_propagate_inbounds_meta
-                sadata = sa.data
+                sadata = parent(sa)
                 @inbounds $(Expr(:block, exprs...))
             end
         else
@@ -257,7 +257,7 @@ end
                 if size(v) != $newsize
                     throw(DimensionMismatch("tried to assign array of size $(size(v)) to destination of size $($newsize)"))
                 end
-                sadata = sa.data
+                sadata = parent(sa)
                 @inbounds $(Expr(:block, exprs...))
             end
         end
@@ -269,7 +269,7 @@ end
             return quote
                 Base.@_propagate_inbounds_meta
                 $(lininds[1])
-                sadata = sa.data
+                sadata = parent(sa)
                 @inbounds $(Expr(:block, exprs...))
             end
         else
@@ -279,7 +279,7 @@ end
                     throw(DimensionMismatch("tried to assign array of size $(size(v)) to destination of size $($newsize)"))
                 end
                 $(lininds[1])
-                sadata = sa.data
+                sadata = parent(sa)
                 @inbounds $(Expr(:block, exprs...))
             end
         end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -49,7 +49,7 @@ const HybridVecOrMatLike{T} = Union{HybridVector{<:Any, T}, HybridMatrixLike{T}}
 
     return quote
         Base.@_inline_meta
-        @inbounds return _h_similar_type($a, promote_type(eltype(a), eltype(b)), Size($Snew))(vcat(a.data, b.data))
+        @inbounds return _h_similar_type($a, promote_type(eltype(a), eltype(b)), Size($Snew))(vcat(parent(a), parent(b)))
     end
 end
 
@@ -68,6 +68,6 @@ end
 
     return quote
         Base.@_inline_meta
-        return _h_similar_type($a, promote_type(eltype(a), eltype(b)), Size($Snew))(hcat(a.data, b.data))
+        return _h_similar_type($a, promote_type(eltype(a), eltype(b)), Size($Snew))(hcat(parent(a), parent(b)))
     end
 end

--- a/test/array_interface_compat.jl
+++ b/test/array_interface_compat.jl
@@ -16,10 +16,10 @@ using ArrayInterface: StaticInt
     @test (@inferred ArrayInterface.strides(MV)) === (2, 30)
     @test (@inferred ArrayInterface.size(M2)) === (StaticInt(2), StaticInt(3), 5, 7)
 
-    @test ArrayInterface.contiguous_axis(typeof(M2)) === ArrayInterface.contiguous_axis(typeof(M2.data))
-    @test ArrayInterface.contiguous_batch_size(typeof(M2)) === ArrayInterface.contiguous_batch_size(typeof(M2.data))
-    @test ArrayInterface.stride_rank(typeof(M2)) === ArrayInterface.stride_rank(typeof(M2.data))
-    @test ArrayInterface.contiguous_axis(typeof(M')) === ArrayInterface.contiguous_axis(typeof(M.data'))
-    @test ArrayInterface.contiguous_batch_size(typeof(M')) === ArrayInterface.contiguous_batch_size(typeof(M.data'))
-    @test ArrayInterface.stride_rank(typeof(M')) === ArrayInterface.stride_rank(typeof(M.data'))
+    @test ArrayInterface.contiguous_axis(typeof(M2)) === ArrayInterface.contiguous_axis(typeof(parent(M2)))
+    @test ArrayInterface.contiguous_batch_size(typeof(M2)) === ArrayInterface.contiguous_batch_size(typeof(parent(M2)))
+    @test ArrayInterface.stride_rank(typeof(M2)) === ArrayInterface.stride_rank(typeof(parent(M2)))
+    @test ArrayInterface.contiguous_axis(typeof(M')) === ArrayInterface.contiguous_axis(typeof(parent(M)'))
+    @test ArrayInterface.contiguous_batch_size(typeof(M')) === ArrayInterface.contiguous_batch_size(typeof(parent(M)'))
+    @test ArrayInterface.stride_rank(typeof(M')) === ArrayInterface.stride_rank(typeof(parent(M)'))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,11 +5,11 @@ using Test
 @test length(Test.detect_ambiguities(HybridArrays)) == 0
 
 @testset "Inner Constructors" begin
-    @test HybridArray{Tuple{2}, Int, 1, 1, Vector{Int}}((3, 4)).data == [3, 4]
-    @test HybridArray{Tuple{2}, Int, 1}([3, 4]).data == [3, 4]
-    @test HybridArray{Tuple{2, 2}, Int, 2}(collect(3:6)).data == collect(3:6)
-    @test size(HybridArray{Tuple{4, 5}, Int, 2}(undef).data) == (4, 5)
-    @test size(HybridArray{Tuple{4, 5}, Int}(undef).data) == (4, 5)
+    @test parent(HybridArray{Tuple{2}, Int, 1, 1, Vector{Int}}((3, 4))) == [3, 4]
+    @test parent(HybridArray{Tuple{2}, Int, 1}([3, 4])) == [3, 4]
+    @test parent(HybridArray{Tuple{2, 2}, Int, 2}(collect(3:6))) == collect(3:6)
+    @test size(parent(HybridArray{Tuple{4, 5}, Int, 2}(undef))) == (4, 5)
+    @test size(parent(HybridArray{Tuple{4, 5}, Int}(undef))) == (4, 5)
 
     # Bad input
     @test_throws Exception SArray{Tuple{1},Int,1}([2 3])
@@ -61,7 +61,7 @@ end
 @testset "setindex" begin
     sa = HybridArray{Tuple{2}, Int, 1}([3, 4])
     sa[1] = 2
-    @test sa.data == [2, 4]
+    @test parent(sa) == [2, 4]
 end
 
 @testset "aliasing" begin


### PR DESCRIPTION
`Base.parent` and `Base.elsize` are additional parts of the common interface which are nice to have in some situations. By specializing `Base.parent` on `sa::HybridArray`, many internal implementations become independent of the name chosen for `sa.data`.