### PR TITLE
adapt tests to recent change in EllipsisNotation.jl

### DIFF
--- a/test/nonstandard_indices.jl
+++ b/test/nonstandard_indices.jl
@@ -16,7 +16,7 @@ using Test
 
   @test_broken typeof(u_hybrid[1, ..]) == typeof(u_hybrid[1, :])
   @test_broken typeof(u_hybrid[.., 1]) == typeof(u_hybrid[:, 1])
-  @test typeof(u_hybrid[..])    == typeof(u_hybrid[:, :])
+  @test_broken typeof(u_hybrid[..])    == typeof(u_hybrid[:])
 
   @inferred u_hybrid[1, ..]
   @inferred u_hybrid[.., 1]


### PR DESCRIPTION
One of the new tests started to fail because of an internal update in EllipsisNotation.jl