### PR TITLE
Fix copy of wrapped SubArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HybridArrays"
 uuid = "1baab800-613f-4b0a-84e4-9cd3431bfbb9"
 authors = ["Mateusz Baran <mateuszbaran89@gmail.com>"]
-version = "0.4.12"
+version = "0.4.13"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -36,7 +36,11 @@ function promote_rule(::Type{<:HybridArray{S,T,N,M,TDataA}}, ::Type{<:HybridArra
     HybridArray{S,TU,N,M,promote_type(TDataA, TDataB)::Type{<:AbstractArray{TU}}}
 end
 
-@inline copy(a::HybridArray) = typeof(a)(copy(parent(a)))
+@inline copy(a::HybridArray{S, T, N, M}) where {S, T, N, M} = begin
+    parentcopy = copy(parent(a))
+    HybridArray{S, T, N, M, typeof(parentcopy)}(parentcopy)
+end
+
 
 homogenized_last(::StaticArrays.HeterogeneousBaseShape) = StaticArrays.Dynamic()
 homogenized_last(a::SOneTo) = last(a)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -47,6 +47,13 @@ using StaticArrays: Dynamic
         M = HybridMatrix{2, Dynamic()}([1 2; 3 4])
         @test @inferred(copy(M))::HybridMatrix == M
         @test parent(copy(M)) !== parent(M)
+
+        @testset "subarrays" begin
+            M = HybridMatrix{Dynamic(), 2}(rand(4, 2))
+            ha = view(M, :, 1)
+            @test copy(ha) == ha
+            @test parent(copy(ha)) !== parent(ha)
+        end
     end
 
     @testset "similar" begin


### PR DESCRIPTION
Should fix the issue where copying a `HybridArray` which wraps a `view()` errors. Let me know if you'd like me to bump the version as well.