### PR TITLE
Test on Julia v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.6', '1.9', '~1.10.0-0']
+        julia-version: ['1.6', '1']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Drop explicit tests on v1.9, and use the latest release in the v1 series for tests