### PR TITLE
Add 1.10 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.6', '1']
+        julia-version: ['1.6', '1.10', '1']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
As 1.10 is the new LTS, this seemed appropriate to me.
Maybe 1.6 should be removed?